### PR TITLE
Fixing clear cache issue on frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,19 @@ Clear Cache for Timber
 ======================
 
 > Contributors: ogrosko
+>
 > Donate link:
+>
 > Tags: cache, clear, flush, twig, Timber
+>
 > Requires at least: 2.0.1
+>
 > Tested up to: 4.4.2
+>
 > Stable tag: 4.4
+>
 > License: GPLv2 or later
+>
 > License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-=== Clear cache for Timber ===
+Clear cache for Timber
+======================
+
 Contributors: ogrosko
 Donate link:
 Tags: cache, clear, flush, twig, Timber
@@ -8,26 +10,37 @@ Stable tag: 4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-== Description ==
+## Description
 
 Small Wordpress plugin for flushing cache of Timber (Twig Template Plugin for Wordpress)
 
-== Installation ==
+## Installation
 
 1. Clone/download and upload the plugin files to the `/wp-content/plugins/` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress
 3. See new button in top panel "Clear Timber Cache" in the admin side
 
 
-== Screenshots ==
+## Screenshots
 
-1. Clear cache for Timber in Wordpress
+![Alt text](/assets/screenshot-1.png?raw=true "Screenshot of plugin")
 
-== Changelog ==
+## Changelog
 
-= 0.0.5 - 11/04/2016 =
-* Removed button from Frontend of site
-* Added markdown README for Github
 
-= 0.0.4 - 11/03/2016 =
-* Cleanup - Some cleanup tasks
+### 0.0.5 (11-04-2016)
+
+Features:
+
+  - Removed button from front end of site
+
+Other:
+
+  - Added markdown README for Github
+
+
+### 0.0.4 (11-03-2016)
+
+Features:
+
+  - Cleanup - Some cleanup tasks

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-Clear cache for Timber
+Clear Cache for Timber
 ======================
 
-Contributors: ogrosko
-Donate link:
-Tags: cache, clear, flush, twig, Timber
-Requires at least: 2.0.1
-Tested up to: 4.4.2
-Stable tag: 4.4
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+> Contributors: ogrosko
+> Donate link:
+> Tags: cache, clear, flush, twig, Timber
+> Requires at least: 2.0.1
+> Tested up to: 4.4.2
+> Stable tag: 4.4
+> License: GPLv2 or later
+> License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 ## Description
 

--- a/clear-cache-for-timber.php
+++ b/clear-cache-for-timber.php
@@ -10,25 +10,30 @@ Network: True
 Text Domain: clear-cache-for-timber
 */
 
-//add button to admin menu bar
-function add_timber_clear_cache_admin_button() {
+/**
+ * Add button to admin menu bar
+ */
+function add_timber_clear_cache_admin_button()
+{
     global $wp_admin_bar;
 
-    if ( !is_super_admin() || !is_admin_bar_showing() || !class_exists('Timber') )
+    if ( !is_super_admin() || !is_admin_bar_showing() || !class_exists('Timber') && !is_admin() ) { 
         return;
+    }
     
-    $wp_admin_bar->add_menu(array(
-        'id' => 'clear-timber-cache',
-        'title' => __( 'Clear Timber Cache'),
-        'href' => '#',
-        'meta' => array(
-        	'html' => '<div class="spinner"></div>',
-        	'onclick' => 'clear_timber_cache(jQuery(this))'
-        )
-    ));
+    if (is_admin()) {
+        $wp_admin_bar->add_menu(array(
+            'id' => 'clear-timber-cache',
+            'title' => __( 'Clear Timber Cache'),
+            'href' => '#',
+            'meta' => array(
+                'html' => '<div class="spinner"></div>',
+                'onclick' => 'clear_timber_cache(jQuery(this))'
+            )
+        ));
+    }
 }
 add_action('admin_bar_menu', 'add_timber_clear_cache_admin_button', 110);
-
 
 /**
  * PHP ajax script
@@ -44,7 +49,7 @@ function clear_timber_cache_callback() {
  */
 add_action( 'admin_footer', 'clear_timer_cache_javascript' );
 function clear_timer_cache_javascript() { 
-	wp_enqueue_script('clear-cache-for-timber-javascript', plugins_url('assets/js/main.js', __FILE__), array(), '0.0.4', true);
+	wp_enqueue_script('clear-cache-for-timber-javascript', plugins_url('assets/js/main.js', __FILE__), array(), '0.0.5', true);
 }
 
 /**
@@ -52,5 +57,5 @@ function clear_timer_cache_javascript() {
  */
 add_action('admin_head', 'clear_timber_cache_style');
 function clear_timber_cache_style() {
-	wp_enqueue_style( 'clear-cache-for-timber-style',  plugins_url('assets/css/style.css', __FILE__), array(), '0.0.4' );
+	wp_enqueue_style( 'clear-cache-for-timber-style',  plugins_url('assets/css/style.css', __FILE__), array(), '0.0.5' );
 }


### PR DESCRIPTION
I have put this plugin through extensive testing on multiple sites and found that it didn't run when clicked on the front end of the site.

I have removed it from the front end but left everything else the same.

I also added a README file for Github just for neatness. I updated the Wordpress readme.txt to match.
